### PR TITLE
Test against Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,24 @@ sudo: false
 
 language: python
 
-python:
-  - "3.6"
+matrix:
+  include:
+    - python: "3.8"
+      env: TOXENV=py38-django2
+
+    - python: "3.8"
+      env: TOXENV=py38-django30
+    - python: "3.8"
+      env: TOXENV=py38-django31
+    - python: "3.8"
+      env: TOXENV=py38-djangomaster
+
+    - python: "3.9"
+      env: TOXENV=py39-django30
+    - python: "3.9"
+      env: TOXENV=py39-django31
+    - python: "3.9"
+      env: TOXENV=py39-djangomaster
 
 install:
   - pip install tox tox-travis

--- a/drf_tweaks/pagination.py
+++ b/drf_tweaks/pagination.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from collections import OrderedDict
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
+
 from rest_framework import status
 from rest_framework.exceptions import APIException
 from rest_framework.pagination import (LimitOffsetPagination, NotFound, PageNumberPagination, remove_query_param,

--- a/drf_tweaks/versioning.py
+++ b/drf_tweaks/versioning.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.conf import settings
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from rest_framework import status
 from rest_framework.exceptions import APIException
 

--- a/tests/test_autofilter.py
+++ b/tests/test_autofilter.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.conf.urls import url
 from django.test import TestCase
 from django.test import override_settings
+from django.urls import re_path
 from django_filters.rest_framework import DjangoFilterBackend
 from django_filters.rest_framework import FilterSet
 from rest_framework import filters
@@ -92,8 +92,8 @@ class SampleApiV6(ListAPIView):
 
 
 urlpatterns = [
-    url(r"^autofilter/$", SampleApiV1.as_view(), name="autofilter_test"),
-    url(r"^autofilter-with-class/$", SampleApiV1.as_view(), name="autofilter_with_class_test"),
+    re_path(r"^autofilter/$", SampleApiV1.as_view(), name="autofilter_test"),
+    re_path(r"^autofilter-with-class/$", SampleApiV1.as_view(), name="autofilter_with_class_test"),
 ]
 
 

--- a/tests/test_autooptimization.py
+++ b/tests/test_autooptimization.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-from django.conf.urls import url
 from rest_framework.permissions import AllowAny
 from django.test import override_settings
+from django.urls import re_path
 from drf_tweaks import serializers
 from rest_framework.serializers import CharField
 from rest_framework.generics import ListAPIView, RetrieveAPIView
@@ -140,15 +140,15 @@ class PrefetchRelatedForcedAPI(AutoOptimizeMixin, ListAPIView):
 
 
 urlpatterns = [
-    url(r"^autooptimization/simple-select-related$", SimpleSelectRelatedAPI.as_view(), name="simple-select-related"),
-    url(r"^autooptimization/simple-prefetch-related$", SimplePrefetchRelatedAPI.as_view(),
-        name="simple-prefetch-related"),
-    url(r"^autooptimization/prefetch-with-select-related$", PrefetchWithSelectRelatedAPI.as_view(),
-        name="prefetch-with-select-related"),
-    url(r"^autooptimization/select-related-by-source$", SelectRelatedBySourceAPI.as_view(),
-        name="select-related-by-source"),
-    url(r"^autooptimization/prefetch-related-forced$", PrefetchRelatedForcedAPI.as_view(),
-        name="prefetch-related-forced"),
+    re_path(r"^autooptimization/simple-select-related$", SimpleSelectRelatedAPI.as_view(), name="simple-select-related"),
+    re_path(r"^autooptimization/simple-prefetch-related$", SimplePrefetchRelatedAPI.as_view(),
+            name="simple-prefetch-related"),
+    re_path(r"^autooptimization/prefetch-with-select-related$", PrefetchWithSelectRelatedAPI.as_view(),
+            name="prefetch-with-select-related"),
+    re_path(r"^autooptimization/select-related-by-source$", SelectRelatedBySourceAPI.as_view(),
+            name="select-related-by-source"),
+    re_path(r"^autooptimization/prefetch-related-forced$", PrefetchRelatedForcedAPI.as_view(),
+            name="prefetch-related-forced"),
 ]
 
 

--- a/tests/test_bulk_edit.py
+++ b/tests/test_bulk_edit.py
@@ -1,6 +1,6 @@
-from django.conf.urls import url
 from django.db import models
 from django.test import override_settings
+from django.urls import re_path
 from django.urls import reverse
 from rest_framework import serializers
 from rest_framework.generics import ListCreateAPIView
@@ -32,7 +32,7 @@ class BulkEditAPI(BulkEditAPIMixin, ListCreateAPIView):
 
 
 urlpatterns = [
-    url(r"^fakeapi$", BulkEditAPI.as_view(), name="bulkedit"),
+    re_path(r"^fakeapi$", BulkEditAPI.as_view(), name="bulkedit"),
 ]
 
 

--- a/tests/test_lock_limiter.py
+++ b/tests/test_lock_limiter.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import pytest
-from django.conf.urls import url
 from django.http import HttpResponse
 from django.test import override_settings
+from django.urls import re_path
 
 from drf_tweaks.test_utils import (
     query_lock_limiter,
@@ -58,7 +58,7 @@ def grabby_select_view(request):
     return HttpResponse()
 
 
-urlpatterns = [url(r"", grabby_select_view, name="sample")]
+urlpatterns = [re_path(r"", grabby_select_view, name="sample")]
 
 
 class TestLockLimiter(DatabaseAccessLintingApiTestCase):

--- a/tests/test_query_counting.py
+++ b/tests/test_query_counting.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import warnings
 
-from django.conf.urls import url
 from django.http import HttpResponse
 from django.test import override_settings
+from django.urls import re_path
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
@@ -32,9 +32,9 @@ def many_calls_partially_frozen_view(request, counted, frozen):
 
 
 urlpatterns = [
-    url(r"^sample/$", custom_view, name="sample"),
-    url(r"^calls/(?P<n>[0-9]+)/$", many_calls_view, name="calls"),
-    url(
+    re_path(r"^sample/$", custom_view, name="sample"),
+    re_path(r"^calls/(?P<n>[0-9]+)/$", many_calls_view, name="calls"),
+    re_path(
         r"^calls-partially-frozen/(?P<counted>[0-9]+)/(?P<frozen>[0-9]+)/$",
         many_calls_partially_frozen_view,
         name="calls-partially-frozen",

--- a/tests/test_serializers_context_passing.py
+++ b/tests/test_serializers_context_passing.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.conf.urls import url
 from django.test import override_settings
+from django.urls import re_path
 from rest_framework import serializers
 from rest_framework.generics import RetrieveUpdateAPIView
 from rest_framework.permissions import AllowAny
@@ -109,8 +109,8 @@ class SampleV2API(RetrieveUpdateAPIView):
 
 
 urlpatterns = [
-    url(r"^test-context-passing/(?P<pk>[\d]+)$", SampleAPI.as_view(), name="test-context-passing"),
-    url(r"^test-context-passing-v2/(?P<pk>[\d]+)$", SampleV2API.as_view(), name="test-context-passing-v2"),
+    re_path(r"^test-context-passing/(?P<pk>[\d]+)$", SampleAPI.as_view(), name="test-context-passing"),
+    re_path(r"^test-context-passing-v2/(?P<pk>[\d]+)$", SampleV2API.as_view(), name="test-context-passing-v2"),
 ]
 
 

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -2,8 +2,8 @@
 from __future__ import unicode_literals
 
 from django.conf import settings
-from django.conf.urls import url
 from django.test import override_settings
+from django.urls import re_path
 from rest_framework import serializers
 from rest_framework.generics import RetrieveUpdateAPIView
 from rest_framework.permissions import AllowAny
@@ -87,12 +87,12 @@ class SampleCustomDeprecatedVersionedApi(ApiVersionMixin, RetrieveUpdateAPIView)
 
 
 urlpatterns = [
-    url(r"^sample/(?P<pk>[\d]+)$", SampleVersionedApi.as_view(), name="sample_api"),
-    url(r"^sample/misconfigured/(?P<pk>[\d]+)$", SampleMisconfiguredApi.as_view(), name="sample_misconfigured_api"),
-    url(r"^sample/deprecated-custom/(?P<pk>[\d]+)$", SampleCustomDeprecatedVersionedApi.as_view(),
-        name="sample_custom_deprecated_api"),
-    url(r"^sample/deprecated-default/(?P<pk>[\d]+)$", SampleDefaultDeprecatedVersionedApi.as_view(),
-        name="sample_default_deprecated_api"),
+    re_path(r"^sample/(?P<pk>[\d]+)$", SampleVersionedApi.as_view(), name="sample_api"),
+    re_path(r"^sample/misconfigured/(?P<pk>[\d]+)$", SampleMisconfiguredApi.as_view(), name="sample_misconfigured_api"),
+    re_path(r"^sample/deprecated-custom/(?P<pk>[\d]+)$", SampleCustomDeprecatedVersionedApi.as_view(),
+            name="sample_custom_deprecated_api"),
+    re_path(r"^sample/deprecated-default/(?P<pk>[\d]+)$", SampleDefaultDeprecatedVersionedApi.as_view(),
+            name="sample_default_deprecated_api"),
 ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@ addopts=--tb=short
 [tox]
 envlist =
         py{38}-lint
-        py{38}-django2
-        py38-django{master}
+        py38-django2
+        py{38,39}-django{30,31,master}
 
 [testenv]
 commands = ./runtests.py --fast {posargs} --coverage -rw
@@ -14,11 +14,14 @@ setenv =
        PYTHONWARNINGS=once
 deps =
         django2: Django>=2.0,<3.0
+        django30: Django>=3.0,<3.1
+        django31: Django>=3.1,<3.2
         djangomaster: https://github.com/django/django/archive/master.tar.gz
         -rrequirements/requirements-base.txt
         -rrequirements/requirements-testing.txt
 basepython =
     py38: python3.8
+    py39: python3.9
 
 [testenv:py38-lint]
 commands = ./runtests.py --lintonly


### PR DESCRIPTION
Also:
* Explicitly test against Django 3.0 and 3.1,
* Remove deprecated `url` and `ugettext_lazy`, and
* Use travis' matrix functionality to run tests with different Python/Django versions.